### PR TITLE
fix: omit empty error and response data in `Response` object

### DIFF
--- a/rpc/types.go
+++ b/rpc/types.go
@@ -19,7 +19,7 @@ type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      interface{}     `json:"id"`
 	Result  json.RawMessage `json:"result"`
-	Error   *ErrorObject    `json:"error"`
+	Error   *ErrorObject    `json:"error,omitempty"`
 }
 
 // NewResponse returns Success/Error response object

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"reflect"
 
 	"github.com/0xPolygon/cdk-rpc/types"
 )
@@ -18,7 +19,7 @@ type Request struct {
 type Response struct {
 	JSONRPC string          `json:"jsonrpc"`
 	ID      interface{}     `json:"id"`
-	Result  json.RawMessage `json:"result"`
+	Result  json.RawMessage `json:"result,omitempty"`
 	Error   *ErrorObject    `json:"error,omitempty"`
 }
 
@@ -30,7 +31,7 @@ func NewResponse(req Request, reply []byte, err Error) Response {
 	}
 
 	var errorObj *ErrorObject
-	if err != nil {
+	if err != nil && !isNil(err) {
 		errorObj = &ErrorObject{
 			Code:    err.ErrorCode(),
 			Message: err.Error(),
@@ -46,6 +47,11 @@ func NewResponse(req Request, reply []byte, err Error) Response {
 		Result:  result,
 		Error:   errorObj,
 	}
+}
+
+// isNil checks if the underlying value of an interface is nil
+func isNil(i interface{}) bool {
+	return i == nil || (reflect.ValueOf(i).Kind() == reflect.Ptr && reflect.ValueOf(i).IsNil())
 }
 
 // Bytes return the serialized response

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -1,0 +1,74 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponse_MarshalUnmarshal(t *testing.T) {
+	tests := []struct {
+		name         string
+		request      Request
+		responseData []byte
+		err          *ErrorObject
+	}{
+		{
+			name: "success response without error",
+			request: Request{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "test_method",
+			},
+			responseData: json.RawMessage(`{"key":"value"}`),
+			err:          nil,
+		},
+		{
+			name: "error response with error",
+			request: Request{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "test_method",
+			},
+			responseData: nil,
+			err: &ErrorObject{
+				Code:    123,
+				Message: "test error",
+				Data:    nil,
+			},
+		},
+		{
+			name: "error response with error and data",
+			request: Request{
+				JSONRPC: "2.0",
+				ID:      float64(1),
+				Method:  "test_method",
+			},
+			responseData: nil,
+			err: &ErrorObject{
+				Code:    123,
+				Message: "test error",
+				Data:    "error data",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var rpcErr *RPCError
+			if tt.err != nil {
+				rpcErr = NewRPCError(tt.err.Code, tt.err.Message, tt.err.Data)
+			}
+
+			resp := NewResponse(tt.request, tt.responseData, rpcErr)
+			data, err := resp.Bytes()
+			require.NoError(t, err)
+
+			var unmarshaledResp Response
+			err = json.Unmarshal(data, &unmarshaledResp)
+			require.NoError(t, err)
+			require.Equal(t, resp, unmarshaledResp)
+		})
+	}
+}

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestResponse_MarshalUnmarshal(t *testing.T) {
+func TestResponseMarshalUnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name         string
 		request      Request


### PR DESCRIPTION
When testing the bridge API, there were cases when the endpoint returned the `null` for error. However, it is not well handled in the library and therefore we end up with the following error

```bash
Deserialization Error: invalid type: null, expected struct JsonRpcError at line 1 column 91. Response: {"jsonrpc":"2.0","id":1,"result":{"tokenMappings":[],"totalTokenMappings":0},"error":null}
```

The proposal is to add `omitempty` tag next to the response result data and error, because we would either have result data or error, but not both).